### PR TITLE
seandstewart/enums-and-uniontypes

### DIFF
--- a/src/typelib/graph.py
+++ b/src/typelib/graph.py
@@ -142,7 +142,7 @@ def get_type_graph(t: type) -> graphlib.TopologicalSorter[TypeNode]:
                 qualname = inspection.qualname(child)
                 *rest, refname = qualname.split(".", maxsplit=1)
                 is_argument = var is not None
-                module = getattr(child, "__module__", None)
+                module = ".".join(rest) or getattr(child, "__module__", None)
                 if module in (None, "__main__") and rest:
                     module = rest[0]
                 is_class = inspect.isclass(child)

--- a/src/typelib/marshals/api.py
+++ b/src/typelib/marshals/api.py
@@ -114,6 +114,8 @@ _HANDLERS: tp.Mapping[
     inspection.isliteral: routines.LiteralMarshaller,
     # Special handler for Unions...
     inspection.isuniontype: routines.UnionMarshaller,
+    # Special handling for Enums
+    inspection.isenumtype: routines.EnumMarshaller,
     # Non-intersecting types (order doesn't matter here.
     inspection.isdatetimetype: routines.DateTimeMarshaller,
     inspection.isdatetype: routines.DateMarshaller,

--- a/src/typelib/marshals/routines.py
+++ b/src/typelib/marshals/routines.py
@@ -6,6 +6,7 @@ import abc
 import contextlib
 import datetime
 import decimal
+import enum
 import fractions
 import pathlib
 import re
@@ -41,6 +42,7 @@ __all__ = (
     "SubscriptedMappingMarshaller",
     "FixedTupleMarshaller",
     "StructuredTypeMarshaller",
+    "EnumMarshaller",
 )
 
 
@@ -150,6 +152,20 @@ UUIDMarshaller = ToStringMarshaller[UUIDT]
 
 PathT = tp.TypeVar("PathT", bound=pathlib.Path)
 PathMarshaller = ToStringMarshaller[PathT]
+
+EnumT = tp.TypeVar("EnumT", bound=enum.Enum)
+
+
+class EnumMarshaller(AbstractMarshaller[EnumT], tp.Generic[EnumT]):
+    """A marshaller that converts an [`enum.Enum`][] instance to its assigned value."""
+
+    def __call__(self, val: EnumT) -> serdes.MarshalledValueT:
+        """Marshal an [`enum.Enum`][] instance into a [`serdes.MarshalledValueT`][].
+
+        Args:
+            val: The enum instance to marshal.
+        """
+        return val.value
 
 
 PatternT = tp.TypeVar("PatternT", bound=re.Pattern)

--- a/src/typelib/py/inspection.py
+++ b/src/typelib/py/inspection.py
@@ -903,7 +903,7 @@ def isenumtype(obj: type) -> compat.TypeIs[type[enum.Enum]]:
         >>> isenumtype(FooNum)
         True
     """
-    return issubclass(obj, enum.Enum)
+    return _safe_issubclass(obj, enum.Enum)
 
 
 @compat.cache

--- a/src/typelib/py/inspection.py
+++ b/src/typelib/py/inspection.py
@@ -480,6 +480,13 @@ def isbuiltintype(
 
 @compat.cache
 def isstdlibtype(obj: type) -> compat.TypeIs[type[STDLibtypeT]]:
+    if isoptionaltype(obj):
+        nargs = tp.get_args(obj)[:-1]
+        return all(isstdlibtype(a) for a in nargs)
+    if isuniontype(obj):
+        args = tp.get_args(obj)
+        return all(isstdlibtype(a) for a in args)
+
     return (
         resolve_supertype(obj) in STDLIB_TYPES
         or resolve_supertype(type(obj)) in STDLIB_TYPES

--- a/src/typelib/unmarshals/api.py
+++ b/src/typelib/unmarshals/api.py
@@ -108,6 +108,8 @@ _HANDLERS: tp.Mapping[
     inspection.isliteral: routines.LiteralUnmarshaller,
     # Special handler for Unions...
     inspection.isuniontype: routines.UnionUnmarshaller,
+    # Special handling for Enums
+    inspection.isenumtype: routines.EnumUnmarshaller,
     # Non-intersecting types (order doesn't matter here.
     inspection.isdatetimetype: routines.DateTimeUnmarshaller,
     inspection.isdatetype: routines.DateUnmarshaller,

--- a/src/typelib/unmarshals/routines.py
+++ b/src/typelib/unmarshals/routines.py
@@ -6,6 +6,7 @@ import abc
 import contextlib
 import datetime
 import decimal
+import enum
 import fractions
 import numbers
 import pathlib
@@ -46,6 +47,7 @@ __all__ = (
     "SubscriptedMappingUnmarshaller",
     "FixedTupleUnmarshaller",
     "StructuredTypeUnmarshaller",
+    "EnumUnmarshaller",
 )
 
 
@@ -537,7 +539,7 @@ PatternT = tp.TypeVar("PatternT", bound=re.Pattern)
 
 
 class PatternUnmarshaller(AbstractUnmarshaller[PatternT], tp.Generic[PatternT]):
-    """Unmarshaller that converts an input to a[`re.Pattern`][].
+    """Unmarshaller that converts an input to a [`re.Pattern`][].
 
     Note:
         You can't instantiate a [`re.Pattern`][] directly, so we don't have a good
@@ -595,6 +597,9 @@ class CastUnmarshaller(AbstractUnmarshaller[T]):
 PathUnmarshaller = CastUnmarshaller[pathlib.Path]
 MappingUnmarshaller = CastUnmarshaller[tp.Mapping]
 IterableUnmarshaller = CastUnmarshaller[tp.Iterable]
+
+EnumT = tp.TypeVar("EnumT", bound=enum.Enum)
+EnumUnmarshaller = CastUnmarshaller[EnumT]
 
 
 LiteralT = tp.TypeVar("LiteralT")

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import enum
 import typing
 
 
@@ -49,3 +50,7 @@ class NTuple(typing.NamedTuple):
 class TDict(typing.TypedDict):
     field: str
     value: int
+
+
+class GivenEnum(enum.Enum):
+    one = "one"

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import datetime
 import enum
 import typing
 
@@ -54,3 +55,10 @@ class TDict(typing.TypedDict):
 
 class GivenEnum(enum.Enum):
     one = "one"
+
+
+@dataclasses.dataclass
+class UnionSTDLib:
+    timestamp: datetime.datetime | None = None
+    date_time: datetime.datetime | None = None
+    intstr: int | str = 0

--- a/tests/unit/marshals/test_api.py
+++ b/tests/unit/marshals/test_api.py
@@ -137,6 +137,11 @@ from tests import models
         ),
         expected_output={"indirect": {"cycle": {"indirect": {"cycle": None}}}},
     ),
+    enum_type=dict(
+        given_type=models.GivenEnum,
+        given_input=models.GivenEnum.one,
+        expected_output=models.GivenEnum.one.value,
+    ),
 )
 def test_marshal(given_type, given_input, expected_output):
     # When

--- a/tests/unit/marshals/test_routines.py
+++ b/tests/unit/marshals/test_routines.py
@@ -449,3 +449,14 @@ def test_invalid_union():
     # When/Then
     with pytest.raises(expected_exception):
         given_marshaller(given_value)
+
+
+def test_enum_unmarshaller():
+    # Given
+    given_unmarshaller = routines.EnumMarshaller(models.GivenEnum, {})
+    given_value = models.GivenEnum.one
+    expected_value = models.GivenEnum.one.value
+    # When
+    unmarshalled = given_unmarshaller(given_value)
+    # Then
+    assert unmarshalled == expected_value

--- a/tests/unit/unmarshals/test_api.py
+++ b/tests/unit/unmarshals/test_api.py
@@ -142,6 +142,13 @@ from tests import models
         given_input="one",
         expected_output=models.GivenEnum.one,
     ),
+    union_std_lib=dict(
+        given_type=models.UnionSTDLib,
+        given_input={"timestamp": 0},
+        expected_output=models.UnionSTDLib(
+            timestamp=datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
+        ),
+    ),
 )
 def test_unmarshal(given_type, given_input, expected_output):
     # When

--- a/tests/unit/unmarshals/test_api.py
+++ b/tests/unit/unmarshals/test_api.py
@@ -137,6 +137,11 @@ from tests import models
         given_input='["1", "2"]',
         expected_output=[1, 2],
     ),
+    enum_type=dict(
+        given_type=models.GivenEnum,
+        given_input="one",
+        expected_output=models.GivenEnum.one,
+    ),
 )
 def test_unmarshal(given_type, given_input, expected_output):
     # When

--- a/tests/unit/unmarshals/test_routines.py
+++ b/tests/unit/unmarshals/test_routines.py
@@ -820,3 +820,14 @@ def test_invalid_union():
     # When/Then
     with pytest.raises(expected_exception):
         given_unmarshaller(given_value)
+
+
+def test_enum_unmarshaller():
+    # Given
+    given_unmarshaller = routines.EnumUnmarshaller(models.GivenEnum, {})
+    given_value = models.GivenEnum.one.value
+    expected_value = models.GivenEnum.one
+    # When
+    unmarshalled = given_unmarshaller(given_value)
+    # Then
+    assert unmarshalled == expected_value


### PR DESCRIPTION
- Add support for marshalling and unmarshalling enum types.
- Fix detection of cyclic types when the target annotation is a union of std-lib types.