### PR TITLE
fix: inspect types when resolving field marshallers for structured types

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,6 @@ name: Make Documentation
 on:
   push:
     branches: ["main"]
-    tags: ["*"]
 
 defaults:
   run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         token: ${{ steps.app-token.outputs.token }}
+        fetch-depth: 0
     - uses: ./.github/actions/bootstrap-environ
       with:
         python-version: 3.x
@@ -110,11 +111,16 @@ jobs:
     - name: Compile Release Notes
       run: make release-notes > release-notes.md
     - name: Report Version
-      run: echo "RELEASE_VERSION=v$(make report-version)" >> $GITHUB_ENV
+      run: |
+        export "RELEASE_VERSION=v$(make report-version)";
+        export "TARGET_COMMITISH=$(git rev-list -n 1 "${RELEASE_VERSION}")";
+        echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+        echo "TARGET_COMMITISH=${TARGET_COMMITISH}" >> $GITHUB_ENV
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
         body_path: release-notes.md
         tag_name: ${{ github.env.RELEASE_VERSION }}
+        target_commitish: ${{ github.env.TARGET_COMMITISH }}
         make_latest: true
         files: dist/*

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,7 @@
 name: Validate
-on: [push, pull_request]
+on:
+  push:
+
 jobs:
   ci:
     uses: ./.github/workflows/.validate-matrix.yml

--- a/src/typelib/unmarshals/routines.py
+++ b/src/typelib/unmarshals/routines.py
@@ -16,7 +16,7 @@ import typing as tp
 import uuid
 
 from typelib import constants, graph, serdes
-from typelib.py import compat, inspection
+from typelib.py import compat, inspection, refs
 
 T = tp.TypeVar("T")
 
@@ -967,7 +967,16 @@ class StructuredTypeUnmarshaller(AbstractUnmarshaller[_ST]):
             var: A variable name for the indicated type annotation (unused, optional).
         """
         super().__init__(t, context, var=var)
-        self.fields_by_var = {m.var: m for m in self.context.values() if m.var}
+        self.fields_by_var = self._fields_by_var()
+
+    def _fields_by_var(self):
+        fields_by_var = {}
+        tp_var_map = {(t.type, t.var): m for t, m in self.context.items()}
+        hints = inspection.cached_type_hints(self.t)
+        for name, hint in hints.items():
+            resolved = refs.evaluate(hint)
+            fields_by_var[name] = tp_var_map[(resolved, name)]
+        return fields_by_var
 
     def __call__(self, val: tp.Any) -> _ST:
         """Unmarshal a value into the bound type.

--- a/tests/models.py
+++ b/tests/models.py
@@ -62,3 +62,24 @@ class UnionSTDLib:
     timestamp: datetime.datetime | None = None
     date_time: datetime.datetime | None = None
     intstr: int | str = 0
+
+
+@dataclasses.dataclass
+class Parent:
+    intersection: ParentIntersect
+    child: Child
+
+
+@dataclasses.dataclass
+class Child:
+    intersection: ChildIntersect
+
+
+@dataclasses.dataclass
+class ParentIntersect:
+    a: int
+
+
+@dataclasses.dataclass
+class ChildIntersect:
+    b: int

--- a/tests/unit/marshals/test_api.py
+++ b/tests/unit/marshals/test_api.py
@@ -142,6 +142,14 @@ from tests import models
         given_input=models.GivenEnum.one,
         expected_output=models.GivenEnum.one.value,
     ),
+    attrib_conflict=dict(
+        given_type=models.Parent,
+        given_input=models.Parent(
+            intersection=models.ParentIntersect(a=0),
+            child=models.Child(intersection=models.ChildIntersect(b=0)),
+        ),
+        expected_output={"intersection": {"a": 0}, "child": {"intersection": {"b": 0}}},
+    ),
 )
 def test_marshal(given_type, given_input, expected_output):
     # When

--- a/tests/unit/marshals/test_routines.py
+++ b/tests/unit/marshals/test_routines.py
@@ -10,6 +10,7 @@ import uuid
 
 import pytest
 
+from typelib import graph
 from typelib.marshals import routines
 
 from tests import models
@@ -386,8 +387,12 @@ def test_fixed_tuple_unmarshaller(
 @pytest.mark.suite(
     context=dict(
         given_context={
-            int: routines.IntegerMarshaller(int, {}, var="value"),
-            str: routines.StringMarshaller(str, {}, var="field"),
+            graph.TypeNode(int, var="value"): routines.IntegerMarshaller(
+                int, {}, var="value"
+            ),
+            graph.TypeNode(str, var="field"): routines.StringMarshaller(
+                str, {}, var="field"
+            ),
         },
         expected_output=dict(field="data", value=1),
     ),

--- a/tests/unit/unmarshals/test_api.py
+++ b/tests/unit/unmarshals/test_api.py
@@ -149,6 +149,14 @@ from tests import models
             timestamp=datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
         ),
     ),
+    attrib_conflict=dict(
+        given_type=models.Parent,
+        given_input={"intersection": {"a": 0}, "child": {"intersection": {"b": 0}}},
+        expected_output=models.Parent(
+            intersection=models.ParentIntersect(a=0),
+            child=models.Child(intersection=models.ChildIntersect(b=0)),
+        ),
+    ),
 )
 def test_unmarshal(given_type, given_input, expected_output):
     # When

--- a/tests/unit/unmarshals/test_routines.py
+++ b/tests/unit/unmarshals/test_routines.py
@@ -10,6 +10,7 @@ import uuid
 
 import pytest
 
+from typelib import graph
 from typelib.unmarshals import routines
 
 from tests import models
@@ -718,44 +719,36 @@ def test_fixed_tuple_unmarshaller(
 
 
 @pytest.mark.suite(
+    context=dict(
+        given_context={
+            graph.TypeNode(int, var="value"): routines.NumberUnmarshaller(
+                int, {}, var="value"
+            ),
+            graph.TypeNode(str, var="field"): routines.StringUnmarshaller(
+                str, {}, var="field"
+            ),
+        },
+    ),
+)
+@pytest.mark.suite(
     dataclass=dict(
         given_cls=models.Data,
-        given_context={
-            int: routines.NumberUnmarshaller(int, {}, var="value"),
-            str: routines.StringUnmarshaller(str, {}, var="field"),
-        },
         expected_output=models.Data(field="data", value=1),
     ),
     vanilla=dict(
         given_cls=models.Vanilla,
-        given_context={
-            int: routines.NumberUnmarshaller(int, {}, var="value"),
-            str: routines.StringUnmarshaller(str, {}, var="field"),
-        },
         expected_output=models.Vanilla(field="data", value=1),
     ),
     vanilla_with_hints=dict(
         given_cls=models.VanillaWithHints,
-        given_context={
-            int: routines.NumberUnmarshaller(int, {}, var="value"),
-            str: routines.StringUnmarshaller(str, {}, var="field"),
-        },
         expected_output=models.VanillaWithHints(field="data", value=1),
     ),
     named_tuple=dict(
         given_cls=models.NTuple,
-        given_context={
-            int: routines.NumberUnmarshaller(int, {}, var="value"),
-            str: routines.StringUnmarshaller(str, {}, var="field"),
-        },
         expected_output=models.NTuple(field="data", value=1),
     ),
     typed_dict=dict(
         given_cls=models.TDict,
-        given_context={
-            int: routines.NumberUnmarshaller(int, {}, var="value"),
-            str: routines.StringUnmarshaller(str, {}, var="field"),
-        },
         expected_output=models.TDict(field="data", value=1),
     ),
 )


### PR DESCRIPTION
- Fixes an issue where two structured types within the same graph have conflicting attribute names, resulting in incorrect marshaller assignment for those fields.
- Fix some issues with job duplication in CI