### PR TITLE
fix: remove use of `graphlib.TypeNode` in type context

### DIFF
--- a/src/typelib/marshals/api.py
+++ b/src/typelib/marshals/api.py
@@ -46,26 +46,24 @@ def marshaller(
             [`typing.ForwardRef`][], or string reference.
     """
     nodes = graph.static_order(t)
-    context: dict[type | graph.TypeNode, routines.AbstractMarshaller] = (
-        ctx.TypeContext()
-    )
+    context: ctx.TypeContext[routines.AbstractMarshaller] = ctx.TypeContext()
     if not nodes:
         return routines.NoOpMarshaller(t=t, context=context, var=None)  # type: ignore[arg-type]
 
     # "root" type will always be the final node in the sequence.
     root = nodes[-1]
     for node in nodes:
-        context[node] = _get_unmarshaller(node, context=context)
+        context[node.type] = _get_unmarshaller(node, context=context)
 
-    return context[root]
+    return context[root.type]
 
 
 def _get_unmarshaller(  # type: ignore[return]
     node: graph.TypeNode,
     context: routines.ContextT,
 ) -> routines.AbstractMarshaller[T]:
-    if node in context:
-        return context[node]
+    if node.type in context:
+        return context[node.type]
 
     for check, unmarshaller_cls in _HANDLERS.items():
         if check(node.type):

--- a/src/typelib/py/refs.py
+++ b/src/typelib/py/refs.py
@@ -18,7 +18,7 @@ import inspect
 import sys
 import typing
 
-from typelib.py import frames, future
+from typelib.py import frames, future, inspection
 
 __all__ = ("ForwardRef", "evaluate", "forwardref")
 
@@ -26,7 +26,7 @@ ForwardRef: typing.TypeAlias = typing.ForwardRef
 
 
 def forwardref(
-    ref: str,
+    ref: str | type,
     *,
     is_argument: bool = False,
     module: typing.Any | None = None,
@@ -43,11 +43,18 @@ def forwardref(
         module: The python module in which the reference string is defined (optional)
         is_class: Whether the reference string is a class (default True).
     """
+    if not isinstance(ref, str):
+        name = inspection.qualname(ref)
+        module = module or getattr(ref, "__module__", None)
+    else:
+        name = typing.cast(str, ref)
+
     module = _resolve_module_name(ref, module)
     if module is not None:
-        ref = ref.replace(f"{module}.", "")
+        name = name.replace(f"{module}.", "")
+
     return ForwardRef(
-        ref,
+        name,
         is_argument=is_argument,
         module=module,
         is_class=is_class,

--- a/src/typelib/unmarshals/api.py
+++ b/src/typelib/unmarshals/api.py
@@ -40,26 +40,24 @@ def unmarshaller(
              May be a type, type alias, [`typing.ForwardRef`][], or string reference.
     """
     nodes = graph.static_order(t)
-    context: dict[type | graph.TypeNode, routines.AbstractUnmarshaller] = (
-        ctx.TypeContext()
-    )
+    context: ctx.TypeContext[routines.AbstractUnmarshaller] = ctx.TypeContext()
     if not nodes:
         return routines.NoOpUnmarshaller(t=t, context=context, var=None)  # type: ignore[arg-type]
 
     # "root" type will always be the final node in the sequence.
     root = nodes[-1]
     for node in nodes:
-        context[node] = _get_unmarshaller(node, context=context)
+        context[node.type] = _get_unmarshaller(node, context=context)
 
-    return context[root]
+    return context[root.type]
 
 
 def _get_unmarshaller(  # type: ignore[return]
     node: graph.TypeNode,
     context: routines.ContextT,
 ) -> routines.AbstractUnmarshaller[T]:
-    if node in context:
-        return context[node]
+    if node.type in context:
+        return context[node.type]
 
     for check, unmarshaller_cls in _HANDLERS.items():
         if check(node.type):

--- a/tests/unit/unmarshals/test_routines.py
+++ b/tests/unit/unmarshals/test_routines.py
@@ -10,7 +10,6 @@ import uuid
 
 import pytest
 
-from typelib import graph
 from typelib.unmarshals import routines
 
 from tests import models
@@ -739,12 +738,8 @@ def test_fixed_tuple_unmarshaller(
 @pytest.mark.suite(
     context=dict(
         given_context={
-            graph.TypeNode(int, var="value"): routines.NumberUnmarshaller(
-                int, {}, var="value"
-            ),
-            graph.TypeNode(str, var="field"): routines.StringUnmarshaller(
-                str, {}, var="field"
-            ),
+            int: routines.NumberUnmarshaller(int, {}, var="value"),
+            str: routines.StringUnmarshaller(str, {}, var="field"),
         },
     ),
 )


### PR DESCRIPTION
This simplifies the work to resolve routines for fields of structured types and reduces the overall footprint of the type context.