### PR TITLE
fix: Unwrap TypeAliasType for all nested types in a type graph

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,11 @@ name: Make Documentation
 on:
   push:
     branches: ["main"]
+    tags-ignore:
+    - '**'
+  release:
+    types:
+    - published
 
 defaults:
   run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,14 @@ jobs:
       with:
         python-version: 3.x
         runner: ubuntu-latest
+    - name: Compile Release Notes
+      run: make release-notes > release-notes.md
+    - name: Report Version
+      run: |
+        export "RELEASE_VERSION=v$(make report-version)";
+        export "TARGET_COMMITISH=$(git rev-list -n 1 "${RELEASE_VERSION}")";
+        echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+        echo "TARGET_COMMITISH=${TARGET_COMMITISH}" >> $GITHUB_ENV
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
@@ -108,14 +116,6 @@ jobs:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
-    - name: Compile Release Notes
-      run: make release-notes > release-notes.md
-    - name: Report Version
-      run: |
-        export "RELEASE_VERSION=v$(make report-version)";
-        export "TARGET_COMMITISH=$(git rev-list -n 1 "${RELEASE_VERSION}")";
-        echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
-        echo "TARGET_COMMITISH=${TARGET_COMMITISH}" >> $GITHUB_ENV
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,10 @@
 name: Validate
 on:
   push:
+    branches:
+    - '**'
+    tags-ignore:
+    - '**'
 
 jobs:
   ci:

--- a/src/typelib/graph.py
+++ b/src/typelib/graph.py
@@ -112,6 +112,9 @@ def get_type_graph(t: type) -> graphlib.TopologicalSorter[TypeNode]:
         resolve one level deep on each attempt, otherwise we will find ourselves stuck
         in a closed loop which never terminates (infinite recursion).
     """
+    if inspection.istypealiastype(t):
+        t = t.__value__
+
     graph: graphlib.TopologicalSorter = graphlib.TopologicalSorter()
     root = TypeNode(t)
     stack = collections.deque([root])
@@ -127,6 +130,8 @@ def get_type_graph(t: type) -> graphlib.TopologicalSorter[TypeNode]:
             # If no type was provided, there's no reason to do further processing.
             if child in (constants.empty, typing.Any):
                 continue
+            if inspection.istypealiastype(child):
+                child = child.__value__
 
             # Only subscripted generics or non-stdlib types can be cyclic.
             #   i.e., we may get `str` or `datetime` any number of times,

--- a/tests/models.py
+++ b/tests/models.py
@@ -5,6 +5,8 @@ import datetime
 import enum
 import typing
 
+from typelib.py import compat
+
 
 @dataclasses.dataclass
 class RecursiveType:
@@ -83,3 +85,11 @@ class ParentIntersect:
 @dataclasses.dataclass
 class ChildIntersect:
     b: int
+
+
+ListAlias = compat.TypeAliasType("ListAlias", list[int])
+
+
+@dataclasses.dataclass
+class NestedTypeAliasType:
+    alias: ListAlias

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -9,6 +9,9 @@ import pytest
 from typelib import graph
 from typelib.py import refs
 
+from tests import models
+from tests.models import NestedTypeAliasType
+
 
 @dataclasses.dataclass
 class Simple:
@@ -87,6 +90,14 @@ class NoTypes:
         ],
     ),
     any_type=dict(given_type=NoTypes, expected_nodes=[graph.TypeNode(type=NoTypes)]),
+    nested_type_alias=dict(
+        given_type=models.NestedTypeAliasType,
+        expected_nodes=[
+            graph.TypeNode(type=int),
+            graph.TypeNode(type=list[int], var="alias"),
+            graph.TypeNode(type=NestedTypeAliasType),
+        ],
+    ),
 )
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="py3.10+")
 def test_static_order(given_type, expected_nodes):


### PR DESCRIPTION
- Fixes an issue where field types would fail to resolve to an actionable marshaller/unmarshaller if they were a `TypeAliasType`.
