### PR TITLE
fix: Handle recursive and cyclic `TypeAliasType`

### DIFF
--- a/src/typelib/graph.py
+++ b/src/typelib/graph.py
@@ -51,7 +51,8 @@ def static_order(
     # We want to leverage the cache if possible, hence the recursive call.
     #   Shouldn't actually recurse more than once or twice.
     if inspection.istypealiastype(t):
-        return static_order(t.__value__)
+        value = inspection.unwrap(t)
+        return static_order(value)
     if isinstance(t, (str, refs.ForwardRef)):
         ref = refs.forwardref(t) if isinstance(t, str) else t
         t = refs.evaluate(ref)
@@ -80,7 +81,7 @@ def itertypes(
         [`itertypes`][typelib.graph.itertypes].
     """
     if inspection.istypealiastype(t):
-        t = t.__value__
+        t = inspection.unwrap(t)
     if isinstance(t, (str, refs.ForwardRef)):  # pragma: no cover
         ref = refs.forwardref(t) if isinstance(t, str) else t
         t = refs.evaluate(ref)
@@ -113,7 +114,7 @@ def get_type_graph(t: type) -> graphlib.TopologicalSorter[TypeNode]:
         in a closed loop which never terminates (infinite recursion).
     """
     if inspection.istypealiastype(t):
-        t = t.__value__
+        t = inspection.unwrap(t)
 
     graph: graphlib.TopologicalSorter = graphlib.TopologicalSorter()
     root = TypeNode(t)
@@ -131,7 +132,7 @@ def get_type_graph(t: type) -> graphlib.TopologicalSorter[TypeNode]:
             if child in (constants.empty, typing.Any):
                 continue
             if inspection.istypealiastype(child):
-                child = child.__value__
+                child = inspection.unwrap(child)
 
             # Only subscripted generics or non-stdlib types can be cyclic.
             #   i.e., we may get `str` or `datetime` any number of times,

--- a/src/typelib/marshals/routines.py
+++ b/src/typelib/marshals/routines.py
@@ -273,7 +273,7 @@ class UnionMarshaller(AbstractMarshaller[UnionT], tp.Generic[UnionT]):
             var: A variable name for the indicated type annotation (unused, optional).
         """
         super().__init__(t, context, var=var)
-        self.stack = inspection.args(t)
+        self.stack = inspection.args(t, evaluate=True)
         self.nullable = inspection.isoptionaltype(t)
         self.ordered_routines = [self.context[typ] for typ in self.stack]
 
@@ -352,7 +352,7 @@ class SubscriptedMappingMarshaller(AbstractMarshaller[MappingT], tp.Generic[Mapp
             var: A variable name for the indicated type annotation (unused, optional).
         """
         super().__init__(t, context, var=var)
-        key_t, value_t = inspection.args(t)
+        key_t, value_t = inspection.args(t, evaluate=True)
         self.keys = context[key_t]
         self.values = context[value_t]
 
@@ -387,7 +387,7 @@ class SubscriptedIterableMarshaller(
         """
         super().__init__(t=t, context=context, var=var)
         # supporting tuple[str, ...]
-        (value_t, *_) = inspection.args(t)
+        (value_t, *_) = inspection.args(t, evaluate=True)
         self.values = context[value_t]
 
     def __call__(self, val: IterableT) -> MarshalledIterableT:
@@ -423,7 +423,7 @@ class FixedTupleMarshaller(AbstractMarshaller[compat.TupleT]):
             var: A variable name for the indicated type annotation (unused, optional).
         """
         super().__init__(t, context, var=var)
-        self.stack = inspection.args(t)
+        self.stack = inspection.args(t, evaluate=True)
         self.ordered_routines = [self.context[vt] for vt in self.stack]
 
     def __call__(self, val: compat.TupleT) -> MarshalledIterableT:

--- a/src/typelib/unmarshals/routines.py
+++ b/src/typelib/unmarshals/routines.py
@@ -628,7 +628,7 @@ class LiteralUnmarshaller(AbstractUnmarshaller[LiteralT], tp.Generic[LiteralT]):
             var: A variable name for the indicated type annotation (unused, optional).
         """
         super().__init__(t, context, var=var)
-        self.values = inspection.args(t)
+        self.values = inspection.args(t, evaluate=True)
 
     def __call__(self, val: tp.Any) -> LiteralT:
         if val in self.values:
@@ -677,7 +677,7 @@ class UnionUnmarshaller(AbstractUnmarshaller[UnionT], tp.Generic[UnionT]):
             var: A variable name for the indicated type annotation (unused, optional).
         """
         super().__init__(t, context, var=var)
-        self.stack = inspection.args(t)
+        self.stack = inspection.args(t, evaluate=True)
         if inspection.isoptionaltype(t):
             self.stack = (self.stack[-1], *self.stack[:-1])
 
@@ -746,7 +746,7 @@ class SubscriptedMappingUnmarshaller(
             var: A variable name for the indicated type annotation (unused, optional).
         """
         super().__init__(t, context, var=var)
-        key_t, value_t = inspection.args(t)
+        key_t, value_t = inspection.args(t, evaluate=True)
         self.keys = context[key_t]
         self.values = context[value_t]
 
@@ -804,7 +804,7 @@ class SubscriptedIterableUnmarshaller(
         """
         super().__init__(t=t, context=context, var=var)
         # supporting tuple[str, ...]
-        (value_t, *_) = inspection.args(t)
+        (value_t, *_) = inspection.args(t, evaluate=True)
         self.values = context[value_t]
 
     def __call__(self, val: tp.Any) -> IterableT:
@@ -857,7 +857,7 @@ class SubscriptedIteratorUnmarshaller(
             var: A variable name for the indicated type annotation (unused, optional).
         """
         super().__init__(t, context, var=var)
-        (value_t,) = inspection.args(t)
+        (value_t,) = inspection.args(t, evaluate=True)
         self.values = context[value_t]
 
     def __call__(self, val: tp.Any) -> IteratorT:
@@ -916,7 +916,7 @@ class FixedTupleUnmarshaller(AbstractUnmarshaller[compat.TupleT]):
             var: A variable name for the indicated type annotation (unused, optional).
         """
         super().__init__(t, context, var=var)
-        self.stack = inspection.args(t)
+        self.stack = inspection.args(t, evaluate=True)
         self.ordered_routines = [self.context[vt] for vt in self.stack]
 
     def __call__(self, val: tp.Any) -> compat.TupleT:

--- a/tests/models.py
+++ b/tests/models.py
@@ -93,3 +93,9 @@ ListAlias = compat.TypeAliasType("ListAlias", list[int])
 @dataclasses.dataclass
 class NestedTypeAliasType:
     alias: ListAlias
+
+
+ValueAlias = compat.TypeAliasType("ValueAlias", int)
+RecursiveAlias = compat.TypeAliasType(
+    "RecursiveAlias", "dict[str, RecursiveAlias | ValueAlias]"
+)

--- a/tests/unit/marshals/test_api.py
+++ b/tests/unit/marshals/test_api.py
@@ -160,6 +160,11 @@ from tests import models
         given_input=models.NestedTypeAliasType(alias=[1]),
         expected_output={"alias": [1]},
     ),
+    recursive_alias=dict(
+        given_type=models.RecursiveAlias,
+        given_input={"cycle": {"cycle": {"cycle": 1}}},
+        expected_output={"cycle": {"cycle": {"cycle": 1}}},
+    ),
 )
 def test_marshal(given_type, given_input, expected_output):
     # When

--- a/tests/unit/unmarshals/test_api.py
+++ b/tests/unit/unmarshals/test_api.py
@@ -167,6 +167,11 @@ from tests import models
         given_input={"alias": ["1"]},
         expected_output=models.NestedTypeAliasType(alias=[1]),
     ),
+    recursive_alias=dict(
+        given_type=models.RecursiveAlias,
+        given_input={"cycle": {"cycle": {"cycle": "1"}}},
+        expected_output={"cycle": {"cycle": {"cycle": 1}}},
+    ),
 )
 def test_unmarshal(given_type, given_input, expected_output):
     # When


### PR DESCRIPTION
- Fixes an issue where a direct recursive or indirect reference to a `TypeAliasType` would produce an unusable type-hint and fail to resolve the forward reference.
